### PR TITLE
Add pkgconfig output

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -120,7 +120,12 @@ example_sources = {
 
 foreach source_file, test_cases : example_sources
   exe_name = source_file.replace('.c', '')
-  exe = executable(exe_name, source_file, dependencies: example_dep)
+  exe = executable(
+    exe_name,
+    source_file,
+    dependencies: example_dep,
+    build_by_default: false
+  )
 
   foreach test_name, args : test_cases
     test(test_name, exe, args: args)

--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,46 @@
-project('plutofilter', 'c', version: '1.0')
+project(
+    'plutofilter',
+    'c',
+    version: '1.0',
+    meson_version: '>=1.0.0',
+    license: 'MIT',
+)
 
 cc = meson.get_compiler('c')
 
 math_dep = cc.find_library('m')
 
 plutofilter_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  dependencies: math_dep
+    include_directories: include_directories('.'),
+    dependencies: math_dep,
 )
 
-subdir('examples')
+if not meson.is_subproject()
+
+    # Meson will not compile a file with *.h
+    fixed_ext = configure_file(
+        input: 'plutofilter.h',
+        output: 'plutofilter.c',
+        copy: true,
+    )
+
+    plutolib = library(
+        'plutofilter',
+        fixed_ext,
+        c_args: ['-DPLUTOFILTER_IMPLEMENTATION'],
+        dependencies: plutofilter_dep,
+        install: true,
+    )
+
+    install_headers('plutofilter.h', subdir: 'plutofilter')
+    
+    pkg = import('pkgconfig')
+    pkg.generate(
+        plutolib,
+        url: 'https://github.com/sammycage/plutofilter/',
+        description: 'single-header, zero-allocation image filter library',
+    )
+
+    subdir('examples')
+
+endif


### PR DESCRIPTION
Thanks for this cool library.

This slightly reworks the meson build, primarily so that it can generate a pkgconfig file for ease of integration.

1. Disable building tests by default. Now they will only build when `meson test` is called
2. Only build the pkgconfig and tests when it is not a subproject. Consumers won't care if it's a subproject.
3. Configure the amalgamation file with a *.c because Meson just ignores it otherwise
4. Build the library (up to user what type)
5. Install the header
6. Generate the pkgconfig file


I do not know what Meson version you are targeting, so I just said 1.0. I also ran meson fmt on the top-level file.